### PR TITLE
getCategories protected function

### DIFF
--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -87,7 +87,7 @@ class Ps_CategoryTree extends Module implements WidgetInterface
         return $output.$this->renderForm();
     }
 
-    private function getCategories($category)
+    protected function getCategories($category)
     {
         $range = '';
         $maxdepth = Configuration::get('BLOCK_CATEG_MAX_DEPTH');


### PR DESCRIPTION
Make getCategories a protected function to allow override.

This is to allow shop owners to override (extend) Ps_CategoryTree and keeping the database logic in the main module