### PR TITLE
$category->getSubCategories() have to use the id_lang

### DIFF
--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -292,7 +292,7 @@ class Ps_CategoryTree extends Module implements WidgetInterface
             $category = new Category($this->context->cookie->last_visited_category, $this->context->language->id);
             if (Configuration::get('BLOCK_CATEG_ROOT_CATEGORY') == 2 && !$category->is_root_category && $category->id_parent) {
                 $category = new Category($category->id_parent, $this->context->language->id);
-            } elseif (Configuration::get('BLOCK_CATEG_ROOT_CATEGORY') == 3 && !$category->is_root_category && !$category->getSubCategories($category->id, true)) {
+            } elseif (Configuration::get('BLOCK_CATEG_ROOT_CATEGORY') == 3 && !$category->is_root_category && !$category->getSubCategories($this->context->language->id, true)) {
                 $category = new Category($category->id_parent, $this->context->language->id);
             }
         }


### PR DESCRIPTION
$category->getSubCategories() have to use the id_lang instead of id_categorie

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?         | bug fix / improvement / new feature / refacto / critical
| BC breaks?    | yes / no
| Deprecations? | yes / no
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
