### PR TITLE
Add number of products after category names in block category tree in side panel

### DIFF
--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -186,7 +186,7 @@ class Ps_CategoryTree extends Module implements WidgetInterface
             'children' => $children,
         ];
 
-        if(Configuration::get('BLOCK_CATEG_SHOW_NUMB_PRODS') == 1){
+        if ((bool) Configuration::get('BLOCK_CATEG_SHOW_NUMB_PRODS')) {
             $return['numberOfProducts'] = (new Category($id_category))->getProducts(
                 $this->context->language->id,
                 1,

--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -109,7 +109,8 @@ class Ps_CategoryTree extends Module implements WidgetInterface
                 Configuration::updateValue('BLOCK_CATEG_SORT_WAY', Tools::getValue('BLOCK_CATEG_SORT_WAY'));
                 Configuration::updateValue('BLOCK_CATEG_SORT', Tools::getValue('BLOCK_CATEG_SORT'));
                 Configuration::updateValue('BLOCK_CATEG_ROOT_CATEGORY', Tools::getValue('BLOCK_CATEG_ROOT_CATEGORY'));
-
+                Configuration::updateValue('BLOCK_CATEG_SHOW_NUMB_PRODS', Tools::getValue('BLOCK_CATEG_SHOW_NUMB_PRODS'));
+                
                 //$this->_clearBlockcategoriesCache();
 
                 Tools::redirectAdmin(AdminController::$currentIndex . '&configure=' . $this->name . '&token=' . Tools::getAdminTokenLite('AdminModules') . '&conf=6');
@@ -177,21 +178,26 @@ class Ps_CategoryTree extends Module implements WidgetInterface
             $link = $name = $desc = '';
         }
 
-        return [
+        $return = [
             'id' => $id_category,
             'link' => $link,
             'name' => $name,
             'desc' => $desc,
             'children' => $children,
-            'numberOfProducts' => (new Category($id_category))->getProducts(
+        ];
+
+        if(Configuration::get('BLOCK_CATEG_SHOW_NUMB_PRODS') == 1){
+            $return['numberOfProducts'] = (new Category($id_category))->getProducts(
                 $this->context->language->id,
                 1,
                 999999999,
                 null,
                 null,
                 true
-            ),
-        ];
+            );
+        }
+
+        return $return;
     }
 
     public function renderForm()
@@ -316,6 +322,7 @@ class Ps_CategoryTree extends Module implements WidgetInterface
             'BLOCK_CATEG_SORT_WAY' => Tools::getValue('BLOCK_CATEG_SORT_WAY', Configuration::get('BLOCK_CATEG_SORT_WAY')),
             'BLOCK_CATEG_SORT' => Tools::getValue('BLOCK_CATEG_SORT', Configuration::get('BLOCK_CATEG_SORT')),
             'BLOCK_CATEG_ROOT_CATEGORY' => Tools::getValue('BLOCK_CATEG_ROOT_CATEGORY', Configuration::get('BLOCK_CATEG_ROOT_CATEGORY')),
+            'BLOCK_CATEG_SHOW_NUMB_PRODS' => Tools::getValue('BLOCK_CATEG_ROOT_CATEGORY', Configuration::get('BLOCK_CATEG_SHOW_NUMB_PRODS')),
         ];
     }
 

--- a/views/templates/hook/ps_categorytree.tpl
+++ b/views/templates/hook/ps_categorytree.tpl
@@ -29,7 +29,7 @@
       <ul>
         {foreach from=$nodes item=node}
           <li>
-            <a href="{$node.link}">{$node.name} ({$node.numberOfProducts})</a>
+            <a href="{$node.link}">{$node.name} {if $node.numberOfProducts}({$node.numberOfProducts}){/if}</a>
             <div>
               {categories nodes=$node.children depth=$depth+1}
             </div>
@@ -42,7 +42,7 @@
 
 <div class="category-tree">
   <ul>
-    <li><a href="{$categories.link nofilter}">{$categories.name} ({$categories.numberOfProducts})</a></li>
+    <li><a href="{$categories.link nofilter}">{$categories.name} {if $categories.numberOfProducts}({$categories.numberOfProducts}){/if}</a></li>
     {if !empty($categories.children)}
       <li>{categories nodes=$categories.children}</li>
     {/if}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR adds a new variable in front templates for each category with the key of `numberOfProducts`. Which lets developers to show the number of products in front office. This also contains a new switch in BO to turn this feature on and off.
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/29129
| How to test?  | Just update the files from commits and test. If the `ps_categorytree.tpl` file is overridden in your theme, you should just change its name to see the result of the original file in module. If you want to see the result of your theme file, you should add this `{if $categories.numberOfProducts}({$categories.numberOfProducts}){/if}` after category name and this `{if $node.numberOfProducts}({$node.numberOfProducts}){/if}` after children name.

This is the image when feature is enabled.
![image](https://user-images.githubusercontent.com/23106000/179968630-54b3ede5-e7e5-419b-a1ba-dc4fdf5e8aaf.png)
This is the BO
![image](https://user-images.githubusercontent.com/23106000/179968929-22515f7f-3d57-4284-9985-a7ee05ca6722.png)
This is when feature is on and the classic theme files are modified after these edits.
![image](https://user-images.githubusercontent.com/23106000/179969075-977fffde-a010-4dc1-9e5b-7ca52da83705.png)