### PR TITLE
Display categories at n+1 of the root

### DIFF
--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -238,6 +238,11 @@ class Ps_CategoryTree extends Module implements WidgetInterface
                                 'value' => static::CATEGORY_ROOT_CURRENT_PARENT,
                                 'label' => $this->getTranslator()->trans('Current category, unless it has no subcategories, in which case the parent category of the current category is used', [], 'Modules.Categorytree.Admin'),
                             ],
+			    [
+                                'id' => 'category_depth_1',
+                                'value' => 4,
+                                'label' => $this->getTranslator()->trans('Categories at n+1 of the root category', [], 'Modules.Categorytree.Admin'),
+                            ],
                         ],
                     ],
                     [
@@ -344,7 +349,17 @@ class Ps_CategoryTree extends Module implements WidgetInterface
             $category = new Category($category->id_parent, $this->context->language->id);
         } elseif (Configuration::get('BLOCK_CATEG_ROOT_CATEGORY') == static::CATEGORY_ROOT_CURRENT_PARENT && !$category->is_root_category && !$category->getSubCategories($category->id, true)) {
             $category = new Category($category->id_parent, $this->context->language->id);
-        }
+        } elseif (Configuration::get('BLOCK_CATEG_ROOT_CATEGORY') == 4) {
+                if ($category->level_depth < 2) {
+                    return [
+                        'categories' => $this->getCategories($category),
+                        'currentCategory' => $category->id,
+                    ];
+                }
+                while ($category->level_depth > 2) {
+                    $category = new Category($category->id_parent);
+                }
+            }
 
         return [
             'categories' => $this->getCategories($category),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description  | This way you can simply display the category at the n+1 of the root which is sometimes more relevant and enable the possibility for a generalist website to specialize the category tree
| Type         |  improvement
| Deprecations | no
| How to test  |  PS 1.7.7.2, php 7.3.2.1

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
