### PR TITLE
Add breadcrumbs info to the categories tree

### DIFF
--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -340,6 +340,27 @@ class Ps_CategoryTree extends Module implements WidgetInterface
         return $this->fetch('module:ps_categorytree/views/templates/hook/ps_categorytree.tpl');
     }
 
+    protected function setBreadcrumbs(&$category, $current)
+    {
+        if ($category['id'] == $current->id) {
+            $category['breadcrumb'] = true;
+            $category['current'] = true;
+
+            return true;
+        }
+
+        foreach ($category['children'] as &$subcategory) {
+            $hasBreadcrumb = $this->setBreadcrumbs($subcategory, $current);
+            if ($hasBreadcrumb) {
+                $category['breadcrumb'] = true;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
         $homeCategory = new Category((int) Configuration::get('PS_HOME_CATEGORY'), $this->context->language->id);
@@ -376,8 +397,14 @@ class Ps_CategoryTree extends Module implements WidgetInterface
             $rootCategory = $homeCategory;
         }
 
+        $categories = $this->getCategories($rootCategory);
+
+        if (Validate::isLoadedObject($currentCategory)) {
+            $this->setBreadcrumbs($categories, $currentCategory);
+        }
+
         return [
-            'categories' => $this->getCategories($rootCategory),
+            'categories' => $categories,
             'currentCategory' => $rootCategory->id,
         ];
     }

--- a/views/templates/hook/ps_categorytree.tpl
+++ b/views/templates/hook/ps_categorytree.tpl
@@ -28,7 +28,7 @@
     {if $nodes|count}
       <ul>
         {foreach from=$nodes item=node}
-          <li>
+          <li{if !empty($node.current)} class="current"{/if}>
             <a href="{$node.link}">{$node.name}</a>
             <div>
               {categories nodes=$node.children depth=$depth+1}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | For user experience it's usually a good idea to treat (e.g. style) in some special way: <br>1. Currently viewed category<br>2. Parent categories (breadcrumbs)<br><br>It helps visitors to navigate through the site.<br><br>This change adds "breadcrumb" and "current" bool properties (set to true) to the relevant categories. This will allow to customze their treating with a front-end code.<br><br>Default template got updated too to add "current" class for relevant `<li>`. Custom templates (e.g. one from the "classic" theme) may also use "breadcrumb" property for unfolding relevant categories by default.<br><br>A similar solution for adding "current" CSS class is used in the _ps_mainmenu_.
| Type?         | new feature
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? |
| How to test?  | 1. Make sure you don't use a custom `ps_categorytree.tpl` (e.g. from the `classic` theme)<br>2. Navigate to some category<br>3. Using web browser developer tools verify that current category list item looks like: `<li class="current">`