### PR TITLE
Return early if no nested categories retrieved

### DIFF
--- a/ps_categorytree.php
+++ b/ps_categorytree.php
@@ -139,6 +139,9 @@ class Ps_CategoryTree extends Module implements WidgetInterface
 
         // Retrieve them using the built in method
         $categories = Category::getNestedCategories($category->id, $this->context->language->id, true, $groups, true, $sqlFilter, $orderBy);
+        if (empty($categories)) {
+            return [];
+        }
 
         // Get path to current category so we can use it for marking
         $idsOfCategoriesInPath = $this->getIdsOfCategoriesInPathToCurrentCategory();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See issue https://github.com/PrestaShop/PrestaShop/issues/37040. In ``Ps_CategoryTree::getCategories()``, If no nested categories are found, the ``array_shift()`` function is called with an empty array, and thus returns null ([per docs](https://www.php.net/manual/en/function.array-shift.php)). This pull request strengthens this method by returning early if no nested categories are returned.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [PrestaShop/Prestashop#37040](https://github.com/PrestaShop/PrestaShop/issues/37040).
| How to test?  | See "how to reproduce" section in issue (TBC).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
