### PR TITLE
Guard the recursive children call to avoid PHP 8 warnings on leaf nodes

### DIFF
--- a/views/templates/hook/ps_categorytree.tpl
+++ b/views/templates/hook/ps_categorytree.tpl
@@ -31,7 +31,9 @@
           <li>
             <a href="{$node.link}">{$node.name}</a>
             <div>
-              {categories nodes=$node.children depth=$depth+1}
+              {if !empty($node.children)}
+                {categories nodes=$node.children depth=$depth+1}
+              {/if}
             </div>
           </li>
         {/foreach}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The recursive `categories` function in `views/templates/hook/ps_categorytree.tpl` passed `$node.children` into its recursive call without checking the key exists. Leaf categories have no `children` key, so on PHP 8 every leaf render emits `Undefined array key "children"`. The top-level call site already guards with `{if !empty($categories.children)}` — this applies the same guard to the recursive call.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/ps_categorytree#86.
| How to test?  | On PHP 8.1+ with a category tree that has both branch and leaf categories, render the widget. Before: each leaf iteration logs `Undefined array key "children"`. After: no warning. Verified by rendering the template with a tree containing a leaf node — 4 `Undefined array key "children"` warnings before, 0 after.
| Sponsor company   |

Root cause reported by @seederp2p. Note: this fixes the module template itself (the source the issue cites); themes that ship their own override of this template should apply the same `!empty()` guard.

